### PR TITLE
Upgrade django rest framework to 3.0.5

### DIFF
--- a/api/apps/predictions/tests/views/test_surge_levels.py
+++ b/api/apps/predictions/tests/views/test_surge_levels.py
@@ -147,13 +147,17 @@ class TestSurgeLevelsEndpoint(APITestCase, PostJsonMixin):
         }
         response = self._post_json([doc])
         assert_equal(400, response.status_code)
+        response_data = decode_json(response.content)
+
+        assert_equal(set(['detail', 'datetime']), set(response_data.keys()))
+
         assert_equal(
             {
                 'detail': 'Failed to deserialize item [0].',
                 'datetime': ['Datetime has wrong format. Use one of these '
                              'formats instead: YYYY-MM-DDThh:mm:00Z']
             },
-            decode_json(response.content))
+            response_data)
 
     def test_that_datetime_with_seconds_is_rejected(self):
         doc = {

--- a/api/apps/predictions/views/surge_levels.py
+++ b/api/apps/predictions/views/surge_levels.py
@@ -1,6 +1,6 @@
 from django.db import transaction
 
-from rest_framework import status
+from rest_framework import status, serializers
 from rest_framework.exceptions import APIException
 from rest_framework.generics import GenericAPIView
 from rest_framework.permissions import DjangoModelPermissionsOrAnonReadOnly
@@ -13,10 +13,6 @@ from ..serializers import SurgeLevelSerializer
 
 
 class JsonFormatError(APIException):
-    status_code = 400
-
-
-class InvalidDataError(APIException):
     status_code = 400
 
 
@@ -54,7 +50,7 @@ class SurgeLevels(GenericAPIView):
                 error_dict = {
                     'detail': 'Failed to deserialize item [{}].'.format(i)}
                 error_dict.update(serializer.errors)
-                raise InvalidDataError(error_dict)
+                raise serializers.ValidationError(detail=error_dict)
 
         return Response({'detail': 'OK.'}, status=status.HTTP_200_OK)
 

--- a/api/apps/tide_gauges/views/raw_measurements.py
+++ b/api/apps/tide_gauges/views/raw_measurements.py
@@ -1,4 +1,3 @@
-from rest_framework.exceptions import APIException
 from rest_framework.generics import GenericAPIView
 from rest_framework.permissions import DjangoModelPermissionsOrAnonReadOnly
 from rest_framework.response import Response
@@ -6,10 +5,6 @@ from rest_framework import status
 
 from ..serializers import RawMeasurementListSerializer
 from ..models import RawMeasurement, TideGauge
-
-
-class InvalidDataError(APIException):
-    status_code = 400
 
 
 class RawMeasurements(GenericAPIView):
@@ -27,9 +22,8 @@ class RawMeasurements(GenericAPIView):
 
         serializer = RawMeasurementListSerializer(data=request.data)
 
-        if not serializer.is_valid():
-            raise InvalidDataError(serializer.errors)
-        serializer.save(tide_gauge=tide_gauge)
+        if serializer.is_valid(raise_exception=True):
+            serializer.save(tide_gauge=tide_gauge)
 
         return Response({'detail': 'OK.'}, status=status.HTTP_200_OK)
 

--- a/requirements/_common.txt
+++ b/requirements/_common.txt
@@ -1,8 +1,5 @@
-# TODO: install from PYPI once it's released there, eg:
-# djangorestframework==3.0.0
--e git+https://github.com/tomchristie/django-rest-framework.git@4e001dbb7ac0bc13d6d5fbb4524e905184610aa2#egg=rest_framework
-
 Django==1.7.4
+djangorestframework==3.0.5
 django-filter==0.9.2
 Markdown==2.5.2
 pytz==2014.10                                                                    


### PR DESCRIPTION
We were using a pre-release version, it's been out for a while now.

Use `serializer.ValidationError` rather than `APIException`:

In django rest framework 3, something changed a little with the
`ValidationError` class that meant using an `APIException` would wrap our
error dictionary in an extra `detail` field like this:

```json
{
   "detail": {
       "detail": "foo",
       "datetime": ["blah"]
   }
}
```

.. but using a `ValidationError` restores it to:

```json
{
   "detail": "foo",
   "datetime": ["blah"]
}
```

Ditto for the `raw_measurements` serializer, but do this by letting DRF
raise the error itself.

https://www.pivotaltracker.com/story/show/81675172