### PR TITLE
Simplify `RawMeasurement` view and serializer

### DIFF
--- a/api/apps/tide_gauges/serializers/__init__.py
+++ b/api/apps/tide_gauges/serializers/__init__.py
@@ -1,1 +1,1 @@
-from .raw_measurement_serializer import RawMeasurementListSerializer
+from .raw_measurement_serializer import RawMeasurementSerializer

--- a/api/apps/tide_gauges/serializers/raw_measurement_serializer.py
+++ b/api/apps/tide_gauges/serializers/raw_measurement_serializer.py
@@ -10,52 +10,20 @@ class RawMeasurementSerializer(serializers.Serializer):
     height = serializers.FloatField()
 
     class Meta:
-        model = RawMeasurement
-
-    def update(self, instance, validated_data):
-        # responsible for updating AND saving instance based on validated_data
-        logging.info('RawMeasurementSerializer.update({}, {})'.format(
-            instance, validated_data))
-
-        assert instance.datetime == validated_data['datetime']
-        assert instance.tide_gauge == validated_data['tide_gauge']
-
-        if instance.height != validated_data['height']:
-            instance.height = validated_data['height']
-            instance.save()
-
-        return instance
+        list_serializer_class = serializers.ListSerializer  # Be explicit.
 
     def create(self, validated_data):
-        logging.info('RawMeasurementSerializer.create({})'.format(
+        """
+        Create *or update* a RawMeasurement based on the tide gauge and
+        datetime.
+        """
+        logging.debug('RawMeasurementSerializer.create({})'.format(
             validated_data))
-        instance = RawMeasurement.objects.create(**validated_data)
-        logging.info(instance)
+
+        height = validated_data.pop('height')
+
+        (instance, was_created) = RawMeasurement.objects.update_or_create(
+            tide_gauge=self.context['tide_gauge'],
+            datetime=validated_data['datetime'],
+            defaults={'height': height})
         return instance
-
-
-class RawMeasurementListSerializer(serializers.ListSerializer):
-    child = RawMeasurementSerializer()
-
-    def save(self, tide_gauge):
-        # Adapted from save() in parent ListSerializer
-
-        validated_data = [
-            dict(list(attrs.items()) + [('tide_gauge', tide_gauge)])
-            for attrs in self.validated_data
-        ]
-
-        def create_or_update(attrs):
-            try:
-                existing = tide_gauge.raw_measurements.get(
-                    datetime=attrs['datetime'])
-            except RawMeasurement.DoesNotExist:
-                return self.child.create(attrs)
-            else:
-                return self.child.update(existing, attrs)
-
-        self.instance = [
-            create_or_update(attrs) for attrs in validated_data
-        ]
-
-        return self.instance

--- a/api/apps/tide_gauges/views/raw_measurements.py
+++ b/api/apps/tide_gauges/views/raw_measurements.py
@@ -1,29 +1,43 @@
-from rest_framework.generics import GenericAPIView
+from rest_framework.generics import CreateAPIView
 from rest_framework.permissions import DjangoModelPermissionsOrAnonReadOnly
-from rest_framework.response import Response
-from rest_framework import status
 
-from ..serializers import RawMeasurementListSerializer
+from ..serializers import RawMeasurementSerializer
 from ..models import RawMeasurement, TideGauge
 
+import functools
 
-class RawMeasurements(GenericAPIView):
+
+class RawMeasurements(CreateAPIView):
     """
-    Store raw measurements for a tide gauge. Predictions must be given in a
-    JSON array. Note that any bad prediction in the list will cause the
-    entire batch to be dropped.
+    Save raw measurements for a tide gauge. Measurements must be given in a
+    JSON array.
+
+    - Any measurements which already exist will be updated.
+    - The endpoint returns HTTP 201 CREATED regardless of whether the record
+      was created or updated.
+
+    Note that an invalid record in the list will cause the entire batch to be
+    dropped.
     """
 
     permission_classes = (DjangoModelPermissionsOrAnonReadOnly,)
     queryset = RawMeasurement.objects.none()  # req for DjangoModelPermissions
-    serializer_class = RawMeasurementListSerializer
 
-    def post(self, request, *args, **kwargs):
+    # I prefer not to override `get_serializer()` just to pass in `many=True`.
+    # There may be a better way than using `partial` though.
+    # See http://stackoverflow.com/q/28814806/2920176
+    serializer_class = functools.partial(RawMeasurementSerializer, many=True)
+
+    def get_serializer_context(self, *args, **kwargs):
+        # Augment the default context (containing response etc) with the tide
+        # gauge instance referred to by the slug in the request URL.
+        # This allows access to the serializer so it can create and query
+        # RawMeasurement models.
+
+        c = super(CreateAPIView, self).get_serializer_context(*args, **kwargs)
         tide_gauge = TideGauge.objects.get(slug=self.kwargs['tide_gauge_slug'])
 
-        serializer = RawMeasurementListSerializer(data=request.data)
+        def combine_dicts(a, b):
+            return dict(list(a.items()) + list(b.items()))
 
-        if serializer.is_valid(raise_exception=True):
-            serializer.save(tide_gauge=tide_gauge)
-
-        return Response({'detail': 'OK.'}, status=status.HTTP_200_OK)
+        return combine_dicts(c, {'tide_gauge': tide_gauge})


### PR DESCRIPTION
The documentation says to use `MySerializer(data=foo, many=True)` and set the
`list_serializer_class` meta property, rather than use
`ListSerializer` directly.

Now that DRF has settled down, I've cut out loads of our code in favour of
DRF's own code. In particular:

- Use the `CreateAPIView` to provide the `post` and `create` methods on
 our class-based view (required updating tests, see below)
- Ditch our `RawMeasurementListSerializer` in faovur of the stock
 `ListSerializer`
- Remove `RawMeasurement.update(...)`
- Make `RawMeasurement.create(...)` handle create *or update*

Note that we've changed the format of positive JSON responses inserts.

Before: `{'detail': 'OK.'}` After: `[{'datetime': '...', 'height': '...'},
...]`

Pre-requisite to https://www.pivotaltracker.com/story/show/89016198