### PR TITLE
Add logging to production settings

### DIFF
--- a/api/settings/production.py
+++ b/api/settings/production.py
@@ -5,6 +5,55 @@ import os
 STATIC_ROOT = os.path.join(BASE_DIR, 'static_collected')
 STATIC_URL = '/static/'
 
+# Logging
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': True,
+    'formatters': {
+        'standard': {
+            'format': ("[%(asctime)s] %(levelname)s [%(name)s:%(lineno)s]"
+                       " %(message)s"),
+            'datefmt': "%d-%b-%y %H:%M:%S"
+        },
+    },
+    'handlers': {
+        'null': {
+            'level': 'DEBUG',
+            'class': 'django.utils.log.NullHandler',
+        },
+        'console': {
+            'level': 'INFO',
+            'class': 'logging.StreamHandler',
+            'formatter': 'standard'
+        },
+    },
+    'loggers': {
+        'django.request': {
+            'handlers': ['console'],
+            'level': 'INFO',
+            'propagate': True,  # also handle in parent handler
+        },
+
+        'django.db.backends': {
+            'handlers': ['console'],
+            'level': 'ERROR',
+            'propagate': False,
+        },
+
+        'api.apps': {
+            'handlers': ['console'],
+            'level': 'INFO',
+            'propagate': True,
+        },
+        'api.libs': {
+            'handlers': ['console'],
+            'level': 'INFO',
+            'propagate': True,
+        },
+    },
+}
+
 if os.environ.get('EMERGENCY_DEBUG', 'false') == 'true':
     DEBUG = True
     TEMPLATE_DEBUG = True


### PR DESCRIPTION
Output to console so it's visible with `heroku logs`

[Delivers #92838504]