### PR TITLE
Send emails on Django errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
   postgresql: "9.3"
 env:
   matrix:
-    - DJANGO_SETTINGS_MODULE=api.settings.production DATABASE_URL=postgres://postgres:@localhost:5432/mydatabase SECRET_KEY=abc
+    - DJANGO_SETTINGS_MODULE=api.settings.production DATABASE_URL=postgres://postgres:@localhost:5432/mydatabase SECRET_KEY=abc EMAIL_HOST_USER=foo EMAIL_HOST_PASSWORD=bar
   global:
     # Contains GH_TOKEN=<secret token> for release tagging
     secure: "d56JXdlDxjZws8+dvvZ/RV/m7wr8+CdFPOabRFWzzo2sV7CsBjlc7vuCT1OAWbGMmt0Q9jQvjt3axHxI5/fbmEetBy4vlnIq5apPCrpNMZRo+iMt+GlMxmueq+RdrTyClH/T/790E6egsIoP6HUHHf6tlAhiNRKm7PUhQoNUbx4="

--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ heroku addons:add pgbackups --app ${APP_NAME}
 # SECRET_KEY
 heroku config:set SECRET_KEY=$(openssl rand -base64 64) --app ${APP_NAME}
 
+# EMAIL
+# Send email via eg Amazon SES
+
+heroku config:set EMAIL_HOST_USER=${SMTP_USERNAME} --app ${APP_NAME}
+heroku config:set EMAIL_HOST_PASSWORD=${SMTP_PASSWORD} --app ${APP_NAME}
+
 # SCHEDULER
 heroku addons:add scheduler --app ${APP_NAME}
 

--- a/api/settings/common.py
+++ b/api/settings/common.py
@@ -36,6 +36,14 @@ SECRET_KEY = os.environ.get('SECRET_KEY', None)
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = TEMPLATE_DEBUG = False
 
+ADMINS = (
+    ('Heroku Admins', 'herokuadmins@sealevelresearch.com'),
+)
+
+MANAGERS = (
+    ('Heroku Managers', 'herokmanagers@sealevelresearch.com'),
+)
+
 ALLOWED_HOSTS = [
     'api.sealevelresearch.com',
     'api-staging.sealevelresearch.com',

--- a/api/settings/common.py
+++ b/api/settings/common.py
@@ -44,6 +44,16 @@ MANAGERS = (
     ('Heroku Managers', 'herokmanagers@sealevelresearch.com'),
 )
 
+# https://docs.djangoproject.com/en/1.7/ref/settings/#server-email
+SERVER_EMAIL = 'heroku@sealevelresearch.com'
+
+# Amazon SES settings
+EMAIL_HOST = 'email-smtp.us-west-2.amazonaws.com'
+EMAIL_PORT = 587
+EMAIL_USE_TLS = True
+EMAIL_USE_SSL = False
+
+
 ALLOWED_HOSTS = [
     'api.sealevelresearch.com',
     'api-staging.sealevelresearch.com',

--- a/api/settings/development.py
+++ b/api/settings/development.py
@@ -22,6 +22,11 @@ INSTALLED_APPS += (
     'debug_toolbar.apps.DebugToolbarConfig',
 )
 
+
+# https://docs.djangoproject.com/en/1.7/topics/email/#console-backend
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
+
 LOG_DIR = pjoin(BASE_DIR, '..', 'log')
 
 LOGGING = {

--- a/api/settings/production.py
+++ b/api/settings/production.py
@@ -2,6 +2,7 @@ from .common import *
 
 import os
 
+
 STATIC_ROOT = os.path.join(BASE_DIR, 'static_collected')
 STATIC_URL = '/static/'
 
@@ -53,6 +54,14 @@ LOGGING = {
         },
     },
 }
+
+# Email
+# https://docs.djangoproject.com/en/dev/topics/email/
+
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_HOST_USER = os.environ['EMAIL_HOST_USER']
+EMAIL_HOST_PASSWORD = os.environ['EMAIL_HOST_PASSWORD']
+
 
 if os.environ.get('EMERGENCY_DEBUG', 'false') == 'true':
     DEBUG = True

--- a/api/settings/production.py
+++ b/api/settings/production.py
@@ -23,6 +23,11 @@ LOGGING = {
             'level': 'DEBUG',
             'class': 'django.utils.log.NullHandler',
         },
+        'mail_admins': {
+            'level': 'ERROR',
+            'class': 'django.utils.log.AdminEmailHandler',
+            'formatter': 'standard',
+        },
         'console': {
             'level': 'INFO',
             'class': 'logging.StreamHandler',
@@ -31,24 +36,24 @@ LOGGING = {
     },
     'loggers': {
         'django.request': {
-            'handlers': ['console'],
+            'handlers': ['console', 'mail_admins'],
             'level': 'INFO',
             'propagate': True,  # also handle in parent handler
         },
 
         'django.db.backends': {
-            'handlers': ['console'],
+            'handlers': ['console', 'mail_admins'],
             'level': 'ERROR',
             'propagate': False,
         },
 
         'api.apps': {
-            'handlers': ['console'],
+            'handlers': ['console', 'mail_admins'],
             'level': 'INFO',
             'propagate': True,
         },
         'api.libs': {
-            'handlers': ['console'],
+            'handlers': ['console', 'mail_admins'],
             'level': 'INFO',
             'propagate': True,
         },


### PR DESCRIPTION
- Add `mail_admins` log handler
- Add `debug` app to help simulate errors
- Add settings for sending email eg `SERVER_EMAIL` and `EMAIL_*`
- Set `ADMINS` and `MANAGERS`

https://www.pivotaltracker.com/story/show/75897458