### PR TITLE
Fix tests broken by django-rest-framework update

### DIFF
--- a/api/apps/predictions/tests/views/test_surge_levels.py
+++ b/api/apps/predictions/tests/views/test_surge_levels.py
@@ -72,7 +72,7 @@ class TestSurgeLevelsEndpoint(APITestCase, PostJsonMixin):
         response = self.client.get(_URL)
         assert_equal(405, response.status_code)
         assert_equal(
-            {'detail': "Method 'GET' not allowed."},
+            {'detail': "Method \"GET\" not allowed."},
             decode_json(response.content))
 
     def test_that_valid_http_post_returns_json_message(self):
@@ -136,7 +136,7 @@ class TestSurgeLevelsEndpoint(APITestCase, PostJsonMixin):
             {
                 'detail': 'Failed to deserialize item [0].',
                 'datetime': ['Datetime has wrong format. Use one of these '
-                             'formats instead: YYYY-MM-DDThh:mm:00Z']
+                             'formats instead: YYYY-MM-DDThh:mm:00Z.']
             },
             decode_json(response.content))
 
@@ -155,7 +155,7 @@ class TestSurgeLevelsEndpoint(APITestCase, PostJsonMixin):
             {
                 'detail': 'Failed to deserialize item [0].',
                 'datetime': ['Datetime has wrong format. Use one of these '
-                             'formats instead: YYYY-MM-DDThh:mm:00Z']
+                             'formats instead: YYYY-MM-DDThh:mm:00Z.']
             },
             response_data)
 
@@ -170,7 +170,7 @@ class TestSurgeLevelsEndpoint(APITestCase, PostJsonMixin):
             {
                 'detail': 'Failed to deserialize item [0].',
                 'datetime': ['Datetime has wrong format. Use one of these '
-                             'formats instead: YYYY-MM-DDThh:mm:00Z']
+                             'formats instead: YYYY-MM-DDThh:mm:00Z.']
             },
             decode_json(response.content))
 

--- a/api/apps/tide_gauges/tests/views/test_post_raw_measurements.py
+++ b/api/apps/tide_gauges/tests/views/test_post_raw_measurements.py
@@ -106,7 +106,7 @@ class TestPostRawMeasurements(TestPutRawMeasurementsBase):
         assert_equal(400, response.status_code)
         assert_equal(
             {'non_field_errors': [
-                'Expected a list of items but got type `dict`.']},
+                'Expected a list of items but got type "dict".']},
             decode_json(response.content))
 
     def test_that_http_post_can_create_single_measurement(self):
@@ -155,7 +155,7 @@ class TestPostRawMeasurements(TestPutRawMeasurementsBase):
         assert_equal(
             [{
                 'datetime': ['Datetime has wrong format. Use one of these '
-                             'formats instead: YYYY-MM-DDThh:mm:00Z']
+                             'formats instead: YYYY-MM-DDThh:mm:00Z.']
             }],
             decode_json(response.content))
 
@@ -169,7 +169,7 @@ class TestPostRawMeasurements(TestPutRawMeasurementsBase):
         assert_equal(
             [{
                 'datetime': ['Datetime has wrong format. Use one of these '
-                             'formats instead: YYYY-MM-DDThh:mm:00Z']
+                             'formats instead: YYYY-MM-DDThh:mm:00Z.']
             }],
             decode_json(response.content))
 
@@ -183,7 +183,7 @@ class TestPostRawMeasurements(TestPutRawMeasurementsBase):
         assert_equal(
             [{
                 'datetime': ['Datetime has wrong format. Use one of these '
-                             'formats instead: YYYY-MM-DDThh:mm:00Z']
+                             'formats instead: YYYY-MM-DDThh:mm:00Z.']
             }],
             decode_json(response.content))
 

--- a/requirements/_common.txt
+++ b/requirements/_common.txt
@@ -1,5 +1,5 @@
 Django==1.7.6
-djangorestframework==3.0.5
+djangorestframework==3.1.0
 django-filter==0.9.2
 Markdown==2.6.1
 pytz==2014.10                                                                    


### PR DESCRIPTION
Changes in JSON output from tomchristie/django-rest-framework somewhere
between 3.0.5 and 3.1.0 broke our tests.

- Use of " rather than `
- Full-stop at the end of a certain message.

See:

- https://github.com/tomchristie/django-rest-framework/commit/91e316f7810157474d6246cd0024bd7f7cc31ff7