### PR TITLE
Modify tooling for new heroku pgbackups

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,6 @@ heroku config:set DJANGO_SETTINGS_MODULE=api.settings.production --app ${APP_NAM
 # DATABASE
 heroku addons:add heroku-postgresql:dev --app ${APP_NAME}
 heroku pg:promote <name of database ie HEROKU_POSTGRESQL_ROSE_URL> --app ${APP_NAME}
-heroku addons:add pgbackups --app ${APP_NAME}
 
 # SECRET_KEY
 heroku config:set SECRET_KEY=$(openssl rand -base64 64) --app ${APP_NAME}

--- a/scripts/copy_db_production_to_dev.sh
+++ b/scripts/copy_db_production_to_dev.sh
@@ -4,7 +4,7 @@ function get_latest_database_dump {
     DUMP_FILE=heroku_production_database.dump
 
     if [ ! -f ${DUMP_FILE} ]; then
-        BACKUP_URL=$(heroku pgbackups:url -a DATABASE_URL --app sea-level-api)
+        BACKUP_URL=$(heroku pg:backups public-url -a DATABASE_URL --app sea-level-api)
         curl -o ${DUMP_FILE} ${BACKUP_URL}
     fi
 }

--- a/scripts/jenkins_deploy_to_heroku.sh
+++ b/scripts/jenkins_deploy_to_heroku.sh
@@ -66,12 +66,12 @@ function copy_production_database_to_staging {
     backup_production_database
     nuke_staging_database
 
-    BACKUP_URL="$(heroku pgbackups:url --app ${PRODUCTION_APP})"
-    heroku pgbackups:restore DATABASE_URL ${BACKUP_URL} --confirm ${STAGING_APP} --app ${STAGING_APP}
+    BACKUP_URL="$(heroku pg:backups public-url --app ${PRODUCTION_APP})"
+    heroku pg:backups restore ${BACKUP_URL} DATABASE_URL --confirm ${STAGING_APP} --app ${STAGING_APP}
 }
 
 function backup_production_database {
-    heroku pgbackups:capture --expire --app ${PRODUCTION_APP}
+    heroku pg:backups capture --app ${PRODUCTION_APP}
 }
 
 function nuke_staging_database {


### PR DESCRIPTION
Heroku have deprecated the `pgbackups` addon in favour of a subcommand of the
`pg` addon, eg `pg:backups`.

See:

- https://devcenter.heroku.com/articles/heroku-postgres-backups
- https://devcenter.heroku.com/articles/mapping-pgbackups-commands

See https://help.heroku.com/tickets/235418