### PR TITLE
Filter locations based on user type

### DIFF
--- a/api/apps/locations/tests/views/test_location_list_filters_based_on_user.py
+++ b/api/apps/locations/tests/views/test_location_list_filters_based_on_user.py
@@ -1,0 +1,78 @@
+from rest_framework.test import APITestCase
+from django.contrib.auth.models import User
+
+from nose.tools import assert_equal
+
+from api.apps.locations.models import Location
+from api.libs.test_utils import decode_json
+
+
+class TestLocationListFiltering(APITestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.location_public = Location.objects.create(
+            slug='public-1', visible=True)
+        cls.location_private_1 = Location.objects.create(
+            slug='private-1', visible=False)
+        cls.location_private_2 = Location.objects.create(
+            slug='private-2', visible=False)
+
+        cls.user_1 = User.objects.create(username='user-1')
+        cls.user_1.user_profile.available_locations.add(cls.location_private_1)
+
+        cls.user_2 = User.objects.create(username='user-2')
+        for location in (cls.location_private_1, cls.location_private_2):
+            cls.user_2.user_profile.available_locations.add(location)
+
+        cls.user_collector = User.objects.create(username='user-collector')
+        cls.user_collector.user_profile.is_internal_collector = True
+        cls.user_collector.user_profile.save()
+
+    @classmethod
+    def tearDownClass(cls):
+        for obj in (cls.location_public, cls.location_private_1,
+                    cls.location_private_2, cls.user_1, cls.user_2,
+                    cls.user_collector):
+            obj.delete()
+
+    PATH = '/1/locations/'
+
+    def _get_locations_for(self, user):
+        if user is not None:
+            self._become_user(user)
+        return self._get_locations()
+
+    def _become_user(self, user):
+        self.client.force_authenticate(user)
+
+    def _get_locations(self):
+        response = self.client.get(self.PATH)
+        assert_equal(200, response.status_code)
+        return set([
+            data['slug']
+            for data in decode_json(response.content)['locations']
+        ])
+
+    def test_that_anonymous_user_sees_public_location(self):
+        assert_equal(
+            set(['public-1']),
+            self._get_locations_for(None)
+        )
+
+    def test_that_user_1_sees_location_1(self):
+        assert_equal(
+            set(['private-1']),
+            self._get_locations_for(self.user_1)
+        )
+
+    def test_that_user_2_sees_locations_1_and_2(self):
+        assert_equal(
+            set(['private-1', 'private-2']),
+            self._get_locations_for(self.user_2)
+        )
+
+    def test_that_collector_user_sees_all_locations(self):
+        assert_equal(
+            set(['private-1', 'private-2', 'public-1']),
+            self._get_locations_for(self.user_collector)
+        )

--- a/api/apps/locations/views/get_queryset.py
+++ b/api/apps/locations/views/get_queryset.py
@@ -1,0 +1,30 @@
+import logging
+
+from api.apps.locations.models import Location
+
+LOG = logging.getLogger(__name__)
+
+
+def get_queryset(user):
+    LOG.info('get_queryset({})'.format(repr(user)))
+
+    if user.is_anonymous():
+        return get_queryset_anonymous()
+
+    elif user.user_profile.is_internal_collector:
+        return get_queryset_collector()
+
+    else:
+        return get_queryset_user(user)
+
+
+def get_queryset_anonymous():
+    return Location.objects.filter(visible=True)
+
+
+def get_queryset_collector():
+    return Location.objects.all()
+
+
+def get_queryset_user(user):
+    return user.user_profile.available_locations

--- a/api/apps/locations/views/location_list.py
+++ b/api/apps/locations/views/location_list.py
@@ -12,5 +12,7 @@ class LocationList(ListAPIView):
     """
     renderer_classes = replace_json_renderer(ListAPIView.renderer_classes)
 
-    queryset = Location.objects.filter(visible=True)
     serializer_class = LocationSerializer
+
+    def get_queryset(self, *args, **kwargs):
+        return Location.objects.filter(visible=True)

--- a/api/apps/locations/views/location_list.py
+++ b/api/apps/locations/views/location_list.py
@@ -1,9 +1,10 @@
 from rest_framework.generics import ListAPIView
 
-from api.apps.locations.models import Location
 from api.apps.locations.serializers import LocationSerializer
 
 from api.libs.json_envelope_renderer import replace_json_renderer
+
+from .get_queryset import get_queryset
 
 
 class LocationList(ListAPIView):
@@ -15,4 +16,4 @@ class LocationList(ListAPIView):
     serializer_class = LocationSerializer
 
     def get_queryset(self, *args, **kwargs):
-        return Location.objects.filter(visible=True)
+        return get_queryset(user=self.request.user)


### PR DESCRIPTION
It filters depending on the three types of user:

1. Anonymous users, who can see "public" or "visible" Locations
2. Logged in users, who can see their own `available_locations` list
3. Collectors, who can see all locations.

See tests.

[#103806680] https://www.pivotaltracker.com/story/show/103806680