### PR TITLE
Add custom permission classes

### DIFF
--- a/api/apps/locations/views/location_list.py
+++ b/api/apps/locations/views/location_list.py
@@ -4,7 +4,7 @@ from api.apps.locations.serializers import LocationSerializer
 
 from api.libs.json_envelope_renderer import replace_json_renderer
 
-from .get_queryset import get_queryset
+from api.libs.user_permissions import get_location_queryset
 
 
 class LocationList(ListAPIView):
@@ -16,4 +16,4 @@ class LocationList(ListAPIView):
     serializer_class = LocationSerializer
 
     def get_queryset(self, *args, **kwargs):
-        return get_queryset(user=self.request.user)
+        return get_location_queryset(user=self.request.user)

--- a/api/libs/user_permissions/__init__.py
+++ b/api/libs/user_permissions/__init__.py
@@ -1,0 +1,2 @@
+from .get_location_queryset import get_location_queryset, user_can_see_location
+from .is_read_request import is_read_request

--- a/api/libs/user_permissions/__init__.py
+++ b/api/libs/user_permissions/__init__.py
@@ -1,2 +1,1 @@
-from .get_location_queryset import get_location_queryset, user_can_see_location
-from .is_read_request import is_read_request
+from .get_location_queryset import get_location_queryset

--- a/api/libs/user_permissions/get_location_queryset.py
+++ b/api/libs/user_permissions/get_location_queryset.py
@@ -5,8 +5,12 @@ from api.apps.locations.models import Location
 LOG = logging.getLogger(__name__)
 
 
-def get_queryset(user):
-    LOG.info('get_queryset({})'.format(repr(user)))
+def get_location_queryset(user):
+    """
+    Return a QuerySet of Locations that a particular User (including an
+    anonymous one) is allowed to view.
+    """
+    LOG.debug('get_location_queryset({})'.format(repr(user)))
 
     if user.is_anonymous():
         return get_queryset_anonymous()
@@ -16,6 +20,14 @@ def get_queryset(user):
 
     else:
         return get_queryset_user(user)
+
+
+def user_can_see_location(user, location):
+    """
+    Return True if the given User is allowed to view the given Location.
+    """
+    locations_for_this_user = get_location_queryset(user)
+    return locations_for_this_user.filter(id=location.id).exists()
 
 
 def get_queryset_anonymous():

--- a/api/libs/user_permissions/is_read_request.py
+++ b/api/libs/user_permissions/is_read_request.py
@@ -1,0 +1,9 @@
+from rest_framework import permissions
+
+
+def is_read_request(request):
+    return request.method in permissions.SAFE_METHODS
+
+
+def is_write_request(request):
+    return not is_read_request(request)

--- a/api/libs/user_permissions/permissions_classes.py
+++ b/api/libs/user_permissions/permissions_classes.py
@@ -2,7 +2,8 @@ import logging
 
 from rest_framework import permissions
 
-from . import is_read_request, user_can_see_location
+from .get_location_queryset import user_can_see_location
+from .is_read_request import is_read_request
 
 LOG = logging.getLogger(__name__)
 

--- a/api/libs/user_permissions/permissions_classes.py
+++ b/api/libs/user_permissions/permissions_classes.py
@@ -1,0 +1,108 @@
+import logging
+
+from rest_framework import permissions
+
+from . import is_read_request, user_can_see_location
+
+LOG = logging.getLogger(__name__)
+
+
+class AllowAnonymousReadPublicLocations(permissions.BasePermission):
+    def has_permission(self, request, view):
+        """
+        Allow anonymous users (not logged in) to perform read-only requests.
+        Don't allow logged-in users to do anything as they aren't our
+        responsibility.
+        """
+        return is_read_request(request) and request.user.is_anonymous()
+
+    def has_object_permission(self, request, view, location):
+        """
+        Allow the (anonymous) user to access whatever locations they are
+        allowed to access.
+
+        In order for this to be called, `has_permission` must have already
+        returned True, so in theory, no need to check `is_read_request` again.
+        However it's easier to test if we just check it again :)
+        """
+        return (is_read_request(request) and
+                user_can_see_location(request.user, location))
+
+
+class AllowInternalCollectorsReadAndWrite(permissions.BasePermission):
+    def has_permission(self, request, view):
+        """
+        If the requesting user is an internal collector, allow them to do
+        anything (read & write).
+
+        If the user is not logged in (AnonymousUser) or not an internal
+        collector, don't let them do anything - that's not our responsibility.
+        """
+        if request.user.is_anonymous():
+            return False
+
+        return request.user.user_profile.is_internal_collector
+
+    def has_object_permission(self, request, view, location):
+        """
+        Return the same as `has_permission` as internal collectors have access
+        to *all* locations, so we don't do any object-based discrimination.
+        """
+        return self.has_permission(request, view)
+
+
+class AllowLoggedInReadTheirLocations(permissions.BasePermission):
+    def has_permission(self, request, view):
+        """
+        Allow logged-in users to perform read-only requests.
+        """
+        return is_read_request(request) and not request.user.is_anonymous()
+
+    def has_object_permission(self, request, view, location):
+        """
+        Allow the logged-in user to access whatever locations they are
+        allowed to access.
+
+        In order for this to be called, `has_permission` must have already
+        returned True, so in theory, no need to check `is_read_request` again.
+        However it's easier to test if we just check it again :)
+        """
+        return (is_read_request(request) and
+                user_can_see_location(request.user, location))
+
+
+class ComposedPermissionsOr(permissions.BasePermission):
+    """
+    Allow access if any of PERMISSION_CLASSES returns True, eg compose them
+    using OR logic.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(ComposedPermissionsOr, self).__init__(*args, **kwargs)
+
+        self.permissions_instances = set(
+            [cls() for cls in self.PERMISSION_CLASSES])
+
+    def has_permission(self, request, view):
+        for instance in self.permissions_instances:
+            if instance.has_permission(request, view):
+                return True
+        return False
+
+    def has_object_permission(self, request, view, obj):
+        for instance in self.permissions_instances:
+            if instance.has_object_permission(request, view, obj) is True:
+                LOG.debug(
+                    '{}.has_object_permission({}, {}, {}) returned '
+                    'True'.format(repr(instance), repr(request.user), view,
+                                  repr(obj)))
+                return True
+        return False
+
+
+class AllowUserSpecificAccess(ComposedPermissionsOr):
+    PERMISSION_CLASSES = set([
+        AllowAnonymousReadPublicLocations,
+        AllowLoggedInReadTheirLocations,
+        AllowInternalCollectorsReadAndWrite,
+    ])

--- a/api/libs/user_permissions/tests/test_permissions.py
+++ b/api/libs/user_permissions/tests/test_permissions.py
@@ -1,0 +1,232 @@
+import collections
+
+from nose.tools import assert_equal
+
+from django.test import TestCase, RequestFactory
+from django.contrib.auth.models import AnonymousUser, User
+
+from api.apps.locations.models import Location
+
+from ..permissions_classes import (
+    AllowUserSpecificAccess, AllowAnonymousReadPublicLocations)
+
+
+PermissionsTestCase = collections.namedtuple(
+    'PermissionsTestCase',
+    ','.join([
+        'expected_has_permission',
+        'expected_has_object_permission',
+        'username',
+        'location',
+        'write_request']))
+
+USERS = {}
+LOCATIONS = {}
+
+
+def setUpModule():
+    global USERS, LOCATIONS
+
+    LOCATIONS = {
+        'location-public-1': Location.objects.create(
+            slug='public-1', name='public-1', visible=True),
+
+        'location-private-1': Location.objects.create(
+            slug='private-1', name='private-1', visible=False),
+
+        'location-private-2': Location.objects.create(
+            slug='private-2', name='private-2', visible=False),
+    }
+
+    USERS = {
+        'user-1': User.objects.create(
+            username='user-1'),
+
+        'user-collector': User.objects.create(
+            username='user-collector'),
+    }
+
+    user_1_profile = USERS['user-1'].user_profile
+    user_1_profile.available_locations.add(
+        LOCATIONS['location-private-1'])
+    user_1_profile.save()
+
+    user_collector_profile = USERS['user-collector'].user_profile
+    user_collector_profile.is_internal_collector = True
+    user_collector_profile.save()
+
+
+def tearDownModule():
+    global USERS, LOCATIONS
+    for obj in list(USERS.values()) + list(LOCATIONS.values()):
+        obj.delete()
+
+
+class TestAnonymousUserPermissions(TestCase):
+
+    def test_can_read_public_location(self):
+        _assert_permissions(AllowUserSpecificAccess, PermissionsTestCase(
+            expected_has_permission=True,
+            expected_has_object_permission=True,
+            username=None,
+            location='location-public-1',
+            write_request=False))
+
+    def test_cannot_read_private_location(self):
+        _assert_permissions(AllowUserSpecificAccess, PermissionsTestCase(
+            expected_has_permission=True,
+            expected_has_object_permission=False,
+            username=None,
+            location='location-private-1',
+            write_request=False))
+
+    def test_cannot_write_public_location(self):
+        _assert_permissions(AllowUserSpecificAccess, PermissionsTestCase(
+            expected_has_permission=False,
+            expected_has_object_permission=False,
+            username=None,
+            location='location-public-1',
+            write_request=True))
+
+    def test_cannot_write_private_location(self):
+        _assert_permissions(AllowUserSpecificAccess, PermissionsTestCase(
+            expected_has_permission=False,
+            expected_has_object_permission=False,
+            username=None,
+            location='location-private-1',
+            write_request=True))
+
+
+class TestLoggedInUserPermissions(TestCase):
+
+    def test_cannot_read_public_location(self):
+        # Strange as it might sound, if the logged in user does not have the
+        # public location in their available locations, is isn't available
+        # to them. This is to prevent eg Southampton users seeing public
+        # Liverpool locations they aren't interested in.
+        # By mirroring the behaviour of the /locations/ endpoint it's much
+        # simpler to comprehend which locations one has access to.
+
+        _assert_permissions(AllowUserSpecificAccess, PermissionsTestCase(
+            expected_has_permission=True,
+            expected_has_object_permission=False,
+            username='user-1',
+            location='location-public-1',
+            write_request=False))
+
+    def test_can_read_private_location_1(self):
+        _assert_permissions(AllowUserSpecificAccess, PermissionsTestCase(
+            expected_has_permission=True,  # generic read should be allowed
+            expected_has_object_permission=True,
+            username='user-1',
+            location='location-private-1',
+            write_request=False))
+
+    def test_cannot_read_private_location_2(self):
+        _assert_permissions(AllowUserSpecificAccess, PermissionsTestCase(
+            expected_has_permission=True,  # generic read should be allowed
+            expected_has_object_permission=False,
+            username='user-1',
+            location='location-private-2',
+            write_request=False))
+
+    def test_cannot_write_public_location(self):
+        _assert_permissions(AllowUserSpecificAccess, PermissionsTestCase(
+            expected_has_permission=False,  # generic write disallowed
+            expected_has_object_permission=False,
+            username='user-1',
+            location='location-public-1',
+            write_request=True))
+
+    def test_cannot_write_private_location_1(self):
+        _assert_permissions(AllowUserSpecificAccess, PermissionsTestCase(
+            expected_has_permission=False,  # generic write disallowed
+            expected_has_object_permission=False,
+            username='user-1',
+            location='location-private-1',
+            write_request=True))
+
+    def test_cannot_write_private_location_2(self):
+        _assert_permissions(AllowUserSpecificAccess, PermissionsTestCase(
+            expected_has_permission=False,  # generic write disallowed
+            expected_has_object_permission=False,
+            username='user-1',
+            location='location-private-2',
+            write_request=True))
+
+
+class TestInternalCollectorUserPermissions(TestCase):
+
+    def test_can_read_public_location(self):
+        _assert_permissions(AllowUserSpecificAccess, PermissionsTestCase(
+            expected_has_permission=True,
+            expected_has_object_permission=True,
+            username='user-collector',
+            location='location-public-1',
+            write_request=False))
+
+    def test_can_read_private_location_1(self):
+        _assert_permissions(AllowUserSpecificAccess, PermissionsTestCase(
+            expected_has_permission=True,
+            expected_has_object_permission=True,
+            username='user-collector',
+            location='location-private-1',
+            write_request=False))
+
+    def test_can_write_public_location(self):
+        _assert_permissions(AllowUserSpecificAccess, PermissionsTestCase(
+            expected_has_permission=True,
+            expected_has_object_permission=True,
+            username='user-collector',
+            location='location-public-1',
+            write_request=True))
+
+    def test_can_write_private_location_1(self):
+        _assert_permissions(AllowUserSpecificAccess, PermissionsTestCase(
+            expected_has_permission=True,
+            expected_has_object_permission=True,
+            username='user-collector',
+            location='location-private-1',
+            write_request=True))
+
+
+def _assert_permissions(permissions_class, case):
+    if case.username is None:
+        user = None
+    else:
+        user = USERS[case.username]
+
+    request = _make_request(case.write_request, user)
+
+    permissions_ob = permissions_class()
+
+    got_has_permission = permissions_ob.has_permission(request, None)
+
+    assert_equal(
+        case.expected_has_permission,
+        got_has_permission
+    )
+
+    if not got_has_permission:
+        # If has_permission returned False, we shouldn't call
+        # has_object_permission as that isn't how DRF works.
+        return
+
+    assert_equal(
+        case.expected_has_object_permission,
+        permissions_ob.has_object_permission(
+            request, None, LOCATIONS[case.location])
+    )
+
+
+def _make_request(write_request, user):
+    factory = RequestFactory()
+    if write_request:
+        request = factory.post('/')
+    else:
+        request = factory.get('/')
+
+    request.user = user if user is not None else AnonymousUser()
+    # force_authenticate(request, user=user)
+
+    return request

--- a/api/libs/user_permissions/tests/test_permissions.py
+++ b/api/libs/user_permissions/tests/test_permissions.py
@@ -7,8 +7,7 @@ from django.contrib.auth.models import AnonymousUser, User
 
 from api.apps.locations.models import Location
 
-from ..permissions_classes import (
-    AllowUserSpecificAccess, AllowAnonymousReadPublicLocations)
+from ..permissions_classes import AllowUserSpecificAccess
 
 
 PermissionsTestCase = collections.namedtuple(


### PR DESCRIPTION
These handle the three user permissions cases, and a composite permissions
object does a logic `OR` of these.

This should allow dropping in `AllowUserSpecificAccess` as a permission
class into views throughout the API.

- Move Location access logic out of Location app
- Create a new `user_permissions` library where the logic can live, and
  ultimately the permission classes used by Django Rest Framework.

https://www.pivotaltracker.com/story/show/89519068