### PR TITLE
Use permissions in tide-levels/windows endpoints

### DIFF
--- a/api/apps/predictions/tests/views/test_database_queries.py
+++ b/api/apps/predictions/tests/views/test_database_queries.py
@@ -4,4 +4,4 @@ class SingleDatabaseQueryTestMixin(object):
     def test_that_all_predictions_are_fetched_with_single_database_query(self):
         # Note that first there is a query on Location
         self.assertNumQueries(
-            2, lambda: self.client.get(self.EXAMPLE_FULL_PATH))
+            3, lambda: self.client.get(self.EXAMPLE_FULL_PATH))

--- a/api/apps/predictions/tests/views/test_permissions.py
+++ b/api/apps/predictions/tests/views/test_permissions.py
@@ -48,3 +48,7 @@ class TestPermissionsMixin(object):
 
 class TestTideLevelsPermissions(TestPermissionsMixin, APITestCase):
     URL = '/1/predictions/tide-levels/{location}/now/'
+
+
+class TestTideWindowsPermissions(TestPermissionsMixin, APITestCase):
+    URL = '/1/predictions/tide-windows/{location}/now/?tide_level=5.0'

--- a/api/apps/predictions/tests/views/test_permissions.py
+++ b/api/apps/predictions/tests/views/test_permissions.py
@@ -1,0 +1,50 @@
+from rest_framework.test import APITestCase
+from nose.tools import assert_equal
+
+from api.libs.user_permissions.tests.create_test_users_locations import (
+    create_test_users_locations,)
+
+TEST_USERS_LOCATIONS = None
+
+
+def setUpModule():
+    global TEST_USERS_LOCATIONS
+    TEST_USERS_LOCATIONS = create_test_users_locations()
+
+
+def tearDownModule():
+    global TEST_USERS_LOCATIONS
+    for obj in TEST_USERS_LOCATIONS.values():
+        obj.delete()
+
+
+class TestPermissionsMixin(object):
+    def assert_status(self, expected_status, location_slug, user):
+        if user is not None:
+            self.client.force_authenticate(TEST_USERS_LOCATIONS[user])
+
+        response = self.client.get(
+            self.URL.format(location=location_slug))
+        assert_equal(expected_status, response.status_code)
+
+    def test_that_anonymous_user_can_see_public_location(self):
+        self.assert_status(200, 'location-public-1', user=None)
+
+    def test_that_anonymous_user_cannot_see_private_location_http_401(self):
+        self.assert_status(401, 'location-private-1', user=None)
+
+    def test_that_user_can_access_own_location(self):
+        self.assert_status(200, 'location-private-1', user='user-1')
+
+    def test_that_user_without_correct_permission_gets_http_403(self):
+        self.assert_status(403, 'location-private-2', user='user-1')
+
+    def test_that_collector_user_can_access_public_location(self):
+        self.assert_status(200, 'location-public-1', user='user-collector')
+
+    def test_that_collector_user_can_access_private_location(self):
+        self.assert_status(200, 'location-private-1', user='user-collector')
+
+
+class TestTideLevelsPermissions(TestPermissionsMixin, APITestCase):
+    URL = '/1/predictions/tide-levels/{location}/now/'

--- a/api/apps/predictions/views/helpers.py
+++ b/api/apps/predictions/views/helpers.py
@@ -1,6 +1,5 @@
 from collections import namedtuple
 from itertools import tee
-from api.libs.param_parsers import parse_location, parse_time_range
 from ..models import TidePrediction
 
 import datetime
@@ -18,12 +17,6 @@ except ImportError:
 TimeRange = namedtuple('TimeRange', 'start,end')
 ONE_DAY = datetime.timedelta(hours=24)
 ONE_MIN = datetime.timedelta(seconds=60)
-
-
-def parse_and_get_queryset(location_slug, start_param, end_param):
-    location = parse_location(location_slug)
-    time_range = parse_time_range(start_param, end_param)
-    return get_queryset(location, time_range)
 
 
 def get_queryset(location, time_range):

--- a/api/apps/predictions/views/tide_levels.py
+++ b/api/apps/predictions/views/tide_levels.py
@@ -19,6 +19,7 @@ class TideLevels(ListAPIView):
     """
     renderer_classes = replace_json_renderer(ListAPIView.renderer_classes)
     serializer_class = TideLevelSerializer
+    permission_classes = (AllowUserSpecificAccess,)
 
     def get_queryset(self, query_params=None, *args, **kwargs):
         if query_params is None:
@@ -27,6 +28,7 @@ class TideLevels(ListAPIView):
         interval_mins = parse_interval(query_params.get('interval', '1'))
         location = parse_location(self.kwargs.get('location_slug', None))
 
+        self.check_object_permissions(self.request, location)
 
         time_range = parse_time_range(
             query_params.get('start', None),

--- a/api/apps/predictions/views/tide_levels.py
+++ b/api/apps/predictions/views/tide_levels.py
@@ -1,11 +1,14 @@
 from rest_framework.generics import ListAPIView
 
 from api.libs.json_envelope_renderer import replace_json_renderer
-from api.libs.param_parsers import parse_interval
+from api.libs.param_parsers import (
+    parse_interval, parse_location, parse_time_range)
+from api.libs.user_permissions.permissions_classes import (
+    AllowUserSpecificAccess,)
 
 from ..serializers import TideLevelSerializer
 
-from .helpers import parse_and_get_queryset
+from .helpers import get_queryset
 
 
 class TideLevels(ListAPIView):
@@ -22,9 +25,13 @@ class TideLevels(ListAPIView):
             query_params = self.request.query_params
 
         interval_mins = parse_interval(query_params.get('interval', '1'))
+        location = parse_location(self.kwargs.get('location_slug', None))
 
-        return parse_and_get_queryset(
-            self.kwargs.get('location_slug', None),
+
+        time_range = parse_time_range(
             query_params.get('start', None),
             query_params.get('end', None)
-        )[:24 * 60:interval_mins]  # limit to 24 hours of data
+        )
+
+        # limit to 24 hours of data
+        return get_queryset(location, time_range)[:24 * 60:interval_mins]

--- a/api/apps/predictions/views/tide_windows.py
+++ b/api/apps/predictions/views/tide_windows.py
@@ -14,6 +14,8 @@ from rest_framework.generics import ListAPIView
 from api.libs.json_envelope_renderer import replace_json_renderer
 from api.libs.param_parsers import (parse_location, parse_time_range,
                                     parse_tide_level)
+from api.libs.user_permissions.permissions_classes import (
+    AllowUserSpecificAccess)
 
 from ..serializers import TideWindowSerializer
 
@@ -32,12 +34,16 @@ class TideWindows(ListAPIView):
     """
     renderer_classes = replace_json_renderer(ListAPIView.renderer_classes)
     serializer_class = TideWindowSerializer
+    permission_classes = (AllowUserSpecificAccess,)
 
     def get_queryset(self, query_params=None, *args, **kwargs):
         if query_params is None:
             query_params = self.request.query_params
 
         location = parse_location(self.kwargs.get('location_slug', None))
+
+        self.check_object_permissions(self.request, location)
+
         time_range = parse_time_range(
             query_params.get('start', None),
             query_params.get('end', None)

--- a/api/libs/user_permissions/tests/create_test_users_locations.py
+++ b/api/libs/user_permissions/tests/create_test_users_locations.py
@@ -1,0 +1,40 @@
+
+from django.contrib.auth.models import User
+
+from api.apps.locations.models import Location
+
+
+def create_test_users_locations():
+
+    test_objects = {
+        'location-public-1': Location.objects.create(
+            slug='location-public-1',
+            name='location-public-1',
+            visible=True),
+
+        'location-private-1': Location.objects.create(
+            slug='location-private-1',
+            name='location-private-1',
+            visible=False),
+
+        'location-private-2': Location.objects.create(
+            slug='location-private-2',
+            name='location-private-2',
+            visible=False),
+
+        'user-1': User.objects.create(
+            username='user-1'),
+
+        'user-collector': User.objects.create(
+            username='user-collector'),
+    }
+
+    user_1_profile = test_objects['user-1'].user_profile
+    user_1_profile.available_locations.add(
+        test_objects['location-private-1'])
+    user_1_profile.save()
+
+    user_collector_profile = test_objects['user-collector'].user_profile
+    user_collector_profile.is_internal_collector = True
+    user_collector_profile.save()
+    return test_objects


### PR DESCRIPTION
- Use the custom permission handler in the Django Rest Framework views
- Check object-level permissions based on the location parsed from the
 URL

https://www.pivotaltracker.com/story/show/103299012 [#103299012]