### PR TITLE
Use custom permission for raw measurements

### DIFF
--- a/api/apps/tide_gauges/tests/views/test_permissions.py
+++ b/api/apps/tide_gauges/tests/views/test_permissions.py
@@ -1,0 +1,69 @@
+from rest_framework.test import APITestCase
+from nose.tools import assert_equal
+
+from api.libs.user_permissions.tests.create_test_users_locations import (
+    create_test_users_locations,)
+
+from api.apps.tide_gauges.models import TideGauge
+
+TIDE_GAUGE = None
+TEST_USERS_LOCATIONS = None
+
+
+def setUpModule():
+    global TIDE_GAUGE, TEST_USERS_LOCATIONS
+    TIDE_GAUGE = TideGauge.objects.create(
+        slug='tide-gauge-1', comment='Tide Gauge 1')
+
+    TEST_USERS_LOCATIONS = create_test_users_locations()
+
+
+def tearDownModule():
+    global TIDE_GAUGE, TEST_USERS_LOCATIONS
+    TIDE_GAUGE.delete()
+
+    for obj in TEST_USERS_LOCATIONS.values():
+        obj.delete()
+
+
+class TestRawMeasurementsPermissions(APITestCase):
+    READ_URL = (
+        '/1/tide-gauges/raw-measurements/tide-gauge-1/'
+        '?start=2014-11-30T00:00:00Z&end=2014-11-30T00:00:00Z'
+    )
+
+    WRITE_URL = '/1/tide-gauges/raw-measurements/tide-gauge-1/'
+
+    def assert_status(self, expected_status, method, user):
+        if user is not None:
+            self.client.force_authenticate(TEST_USERS_LOCATIONS[user])
+
+        if method == 'GET':
+            response = self.client.get(self.READ_URL)
+
+        elif method == 'POST':
+            response = self.client.post(
+                self.WRITE_URL, data='[]', content_type='application/json')
+
+        else:
+            raise ValueError(method)
+
+        assert_equal(expected_status, response.status_code)
+
+    def test_that_anonymous_users_cannot_GET_raw_measurements(self):
+        self.assert_status(401, 'GET', None)
+
+    def test_that_anonymous_users_cannot_POST_raw_measurements(self):
+        self.assert_status(401, 'POST', None)
+
+    def test_that_logged_in_users_cannot_GET_raw_measurements(self):
+        self.assert_status(403, 'GET', 'user-1')
+
+    def test_that_logged_in_users_cannot_POST_raw_measurements(self):
+        self.assert_status(403, 'POST', 'user-1')
+
+    def test_that_collectors_can_GET_raw_measurements(self):
+        self.assert_status(200, 'GET', 'user-collector')
+
+    def test_that_collectors_can_POST_raw_measurements(self):
+        self.assert_status(201, 'POST', 'user-collector')

--- a/api/apps/tide_gauges/tests/views/test_raw_measurements_metadata.py
+++ b/api/apps/tide_gauges/tests/views/test_raw_measurements_metadata.py
@@ -3,6 +3,7 @@ from nose.tools import assert_equal
 from rest_framework.test import APITestCase
 
 from api.apps.tide_gauges.models import TideGauge
+from api.apps.users.helpers import create_user
 
 _URL = ('/1/tide-gauges/raw-measurements/gladstone/'
         '?start=2014-01-01T00:00:00Z'
@@ -14,15 +15,29 @@ class TestRawMeasurementsEndpointMetadata(APITestCase):
     def setUpClass(cls):
         cls.gladstone = TideGauge.objects.create(slug='gladstone')
 
+        cls.normal_user = create_user(
+            'user-normal', is_internal_collector=False)
+
+        cls.collector_user = create_user(
+            'user-collector', is_internal_collector=True)
+
     @classmethod
-    def stearDownClass(cls):
+    def tearDownClass(cls):
         cls.gladstone.delete()
+        cls.normal_user.delete()
+        cls.collector_user.delete()
+
+    def test_that_anonymous_user_cannot_use_http_options(self):
+        response = self.client.options(_URL)
+        assert_equal(401, response.status_code)
+
+    def test_that_non_collector_user_cannot_use_http_options(self):
+        self.client.force_authenticate(self.normal_user)
+        response = self.client.options(_URL)
+        assert_equal(403, response.status_code)
 
     def test_that_http_options_allowed_methods_are_get_post_head_options(self):
+        self.client.force_authenticate(self.collector_user)
         response = self.client.options(_URL)
         assert_equal(200, response.status_code)
         assert_equal('GET, POST, HEAD, OPTIONS', response['Allow'])
-
-    def test_that_http_get_is_allowed(self):
-        response = self.client.get(_URL)
-        assert_equal(200, response.status_code)

--- a/api/apps/tide_gauges/views/raw_measurements.py
+++ b/api/apps/tide_gauges/views/raw_measurements.py
@@ -3,12 +3,13 @@ import datetime
 from django.core.exceptions import ObjectDoesNotExist
 
 from rest_framework.generics import ListCreateAPIView
-from rest_framework.permissions import DjangoModelPermissionsOrAnonReadOnly
 
 from api.libs.param_parsers import (parse_time_range, MissingParameterError,
                                     ObjectNotFoundError, TimeRangeError)
 
 from api.libs.json_envelope_renderer import replace_json_renderer
+from api.libs.user_permissions.permissions_classes import (
+    AllowInternalCollectorsReadAndWrite)
 
 from ..serializers import RawMeasurementSerializer
 from ..models import RawMeasurement, TideGauge
@@ -31,8 +32,7 @@ class RawMeasurements(ListCreateAPIView):
 
     renderer_classes = replace_json_renderer(
         ListCreateAPIView.renderer_classes)
-    permission_classes = (DjangoModelPermissionsOrAnonReadOnly,)
-    queryset = RawMeasurement.objects.none()  # req for DjangoModelPermissions
+    permission_classes = (AllowInternalCollectorsReadAndWrite,)
 
     # I prefer not to override `get_serializer()` just to pass in `many=True`.
     # There may be a better way than using `partial` though.


### PR DESCRIPTION
This endpoint is really only for internal use - it isn't "customer facing"
as it's the underlying raw measurements for a tide gauge (which get
translated to Observations for a Location, depending on the
Location<-->TideGauge relationship)

Use the `AllowInternalCollectorsReadAndWrite` permission class, which
doesn't grant any permissions to anonymous or logged in users.

https://www.pivotaltracker.com/story/show/103299012