### PR TITLE
Make `create_user` helper function

### DIFF
--- a/api/apps/locations/tests/views/test_location_list_filters_based_on_user.py
+++ b/api/apps/locations/tests/views/test_location_list_filters_based_on_user.py
@@ -1,9 +1,9 @@
 from rest_framework.test import APITestCase
-from django.contrib.auth.models import User
 
 from nose.tools import assert_equal
 
 from api.apps.locations.models import Location
+from api.apps.users.helpers import create_user
 from api.libs.test_utils import decode_json
 
 
@@ -17,16 +17,17 @@ class TestLocationListFiltering(APITestCase):
         cls.location_private_2 = Location.objects.create(
             slug='private-2', visible=False)
 
-        cls.user_1 = User.objects.create(username='user-1')
-        cls.user_1.user_profile.available_locations.add(cls.location_private_1)
+        cls.user_1 = create_user(
+            'user-1', available_locations=[cls.location_private_1])
 
-        cls.user_2 = User.objects.create(username='user-2')
-        for location in (cls.location_private_1, cls.location_private_2):
-            cls.user_2.user_profile.available_locations.add(location)
+        cls.user_2 = create_user(
+            'user-2',
+            available_locations=[
+                cls.location_private_1, cls.location_private_2]
+        )
 
-        cls.user_collector = User.objects.create(username='user-collector')
-        cls.user_collector.user_profile.is_internal_collector = True
-        cls.user_collector.user_profile.save()
+        cls.user_collector = create_user(
+            'user-collector', is_internal_collector=True)
 
     @classmethod
     def tearDownClass(cls):

--- a/api/apps/users/helpers/__init__.py
+++ b/api/apps/users/helpers/__init__.py
@@ -1,0 +1,1 @@
+from .create_user import create_user

--- a/api/apps/users/helpers/create_user.py
+++ b/api/apps/users/helpers/create_user.py
@@ -1,0 +1,18 @@
+from django.contrib.auth.models import User
+
+
+def create_user(username, *args, **kwargs):
+    is_internal_collector = kwargs.pop('is_internal_collector', None)
+    available_locations = kwargs.pop('available_locations', [])
+
+    user = User.objects.create(username=username, *args, **kwargs)
+    profile = user.user_profile
+
+    if is_internal_collector is not None:
+        profile.is_internal_collector = is_internal_collector
+
+    for location in available_locations:
+        profile.available_locations.add(location)
+
+    profile.save()
+    return user

--- a/api/libs/user_permissions/tests/create_test_users_locations.py
+++ b/api/libs/user_permissions/tests/create_test_users_locations.py
@@ -1,7 +1,5 @@
-
-from django.contrib.auth.models import User
-
 from api.apps.locations.models import Location
+from api.apps.users.helpers import create_user
 
 
 def create_test_users_locations():
@@ -21,20 +19,16 @@ def create_test_users_locations():
             slug='location-private-2',
             name='location-private-2',
             visible=False),
-
-        'user-1': User.objects.create(
-            username='user-1'),
-
-        'user-collector': User.objects.create(
-            username='user-collector'),
     }
 
-    user_1_profile = test_objects['user-1'].user_profile
-    user_1_profile.available_locations.add(
-        test_objects['location-private-1'])
-    user_1_profile.save()
+    test_objects['user-1'] = create_user(
+        'user-1',
+        available_locations=[test_objects['location-private-1']]
+    )
 
-    user_collector_profile = test_objects['user-collector'].user_profile
-    user_collector_profile.is_internal_collector = True
-    user_collector_profile.save()
+    test_objects['user-collector'] = create_user(
+        'user-collector',
+        is_internal_collector=True
+    )
+
     return test_objects


### PR DESCRIPTION
So that we can do something like:

```
create_user(
    'bob', is_internal_collector=True,
    available_locations=[location])
```

... without having to mess around with getting the `UserProfile` object, 
modifying it and saving it afterwards. This simplifies all code that creates a
user.